### PR TITLE
Move init containers from prototype

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,0 +1,20 @@
+# To build one auto-instrumentation image for dotnet, please:
+#  - Download the newrelic dotnet artefacts to `/instrumentation` directory. This is required as when instrumenting the pod,
+#    one init container will be created to copy the files to your app's container.
+#  - Grant the necessary access to the files in the `/instrumentation` directory.
+#  - Following environment variables are injected to the application container to enable the auto-instrumentation.
+#    CORECLR_ENABLE_PROFILING=1
+#    CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/libNewRelicProfiler.so
+#    CORECLR_NEWRELIC_HOME=%InstallationLocation% 
+
+FROM alpine:latest as build
+RUN apk update && apk add ca-certificates
+ARG version
+ARG architecture
+WORKDIR /instrumentation
+RUN wget -c "https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_${version}_${architecture}.tar.gz" -O - | tar -xz --strip-components 1
+
+FROM busybox
+COPY --from=build /instrumentation /instrumentation
+RUN chmod -R go+r /instrumentation

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,0 +1,8 @@
+# To build one auto-instrumentation image for Java, please:
+#  - Download the newrelic `newrelic-agent-$version.jar` to `/newrelic-agent.jar`. This is required as when instrumenting the pod,
+#    one init container will be created to copy the jar to your app's container.
+#  - Grant the necessary access to the jar. `chmod -R go+r //newrelic-agent.jar`
+FROM busybox
+ARG version
+ADD https://download.newrelic.com/newrelic/java-agent/newrelic-agent/$version/newrelic-agent-$version.jar /newrelic-agent.jar
+RUN chmod -R go+r /newrelic-agent.jar

--- a/nodejs/.dockerignore
+++ b/nodejs/.dockerignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,0 +1,16 @@
+# To build one auto-instrumentation image for Node.js, please:
+# - Ensure the packages are installed in the `/instrumentation` directory. This is required as when instrumenting the pod,
+#   one init container will be created to copy all the content in `/instrumentation` directory to your app's container. Then
+#   update the `NODE_OPTIONS` environment variable accordingly.
+#   In the first stage, install all the required packages in one custom directory.
+#   Then in the second stage, copy the directory to `/instrumentation`.
+# - Ensure you have `newrelic`, `@newrelic/aws-sdk`, `@newrelic/koa`, `@newrelic/superagent`, and `@newrelic/native-metrics`
+# - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
+FROM node:20.12 AS build
+WORKDIR /operator-build
+COPY . .
+RUN npm install
+
+FROM busybox
+COPY --from=build /operator-build/build/workspace /instrumentation
+RUN chmod -R go+r /instrumentation

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "newrelic",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "clean": "rimraf build/*",
+    "prepare": "npm run compile",
+    "compile": "tsc -p .",
+    "postcompile": "copyfiles -f 'build/src/**' build/workspace/ && copyfiles 'node_modules/**' build/workspace/"
+  },
+  "devDependencies": {
+    "copyfiles": "^2.4.1",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.3"
+  },
+  "dependencies": {
+    "newrelic": "11.15.0"
+    }
+}

--- a/nodejs/src/newrelicinstrumentation.ts
+++ b/nodejs/src/newrelicinstrumentation.ts
@@ -1,0 +1,3 @@
+const newrelic = require('newrelic');
+
+export { newrelic };

--- a/nodejs/tsconfig.json
+++ b/nodejs/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "inlineSources": true,
+    "module": "commonjs",
+    "newLine": "LF",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "es2017"
+  },
+  "include": [
+    "src/**/*.ts",
+  ]
+}

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,15 @@
+# To build one auto-instrumentation image for PHP, please:
+#  - Download the newrelic php artefacts to `/instrumentation` directory. This is required as when instrumenting the pod,
+#    one init container will be created to copy the files to your app's container.
+#  - Grant the necessary access to the files in the `/instrumentation` directory.
+FROM alpine:latest as build
+RUN apk update && apk add ca-certificates
+ARG version
+ARG architecture
+ARG php
+WORKDIR /instrumentation
+RUN wget -c "https://download.newrelic.com/php_agent/release/newrelic-${php}-${version}-${architecture}.tar.gz" -O - | tar -xz --strip-components 1
+
+FROM busybox
+COPY --from=build /instrumentation /instrumentation
+RUN chmod -R go+r /instrumentation

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,25 @@
+# To build one auto-instrumentation image for Python, please:
+# - Ensure the packages are installed in the `/instrumentation` directory. This is required as when instrumenting the pod,
+#   one init container will be created to copy all the content in `/instrumentation` directory to your app's container. Then
+#   update the `PYTHONPATH` environment variable accordingly.
+#   In the first stage, install all the required packages in one custom directory with `pip install --target`.
+#   Then in the second stage, copy the directory to `/instrumentation`.
+# - Ensure you have `newrelic-distro` and `newrelic` installed.
+#   Those two packages are essential to Python auto-instrumentation.
+# - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
+
+FROM python:3.10-alpine AS build
+WORKDIR /operator-build
+ARG version
+ENV NEW_RELIC_EXTENSIONS = False
+# WARNING: Disabling optional C extension components of the Python agent 
+# will result in some non core features of the Python agent, such as
+# capacity analysis instance busy metrics, that will not be available.
+# Pure Python versions of code supporting some features, rather than the
+# optimised C versions, will also be used resulting in additional overheads.
+ADD requirements.txt .
+RUN mkdir workspace && pip install --target workspace newrelic==$version
+
+FROM busybox
+COPY --from=build /operator-build/workspace /instrumentation
+RUN chmod -R go+r /instrumentation


### PR DESCRIPTION
Add init containers from https://github.com/newrelic-experimental/newrelic-agent-operator/tree/main/autoinstrumentation and simplify them by adding additional ARGs where needed.

Note Node has not been simplified yet in this regard to reference the version of the node agent from the ARG.