### PR TITLE
ci: Add dotnet ci workflow and tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-                
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0
@@ -124,6 +124,8 @@ jobs:
           account_id: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           api_key: ${{ secrets.NEW_RELIC_API_KEY }}
           license_key: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+          # set the region to Staging if using a staging license key. Also set NEW_RELIC_HOST in tests/chart/templates/deployment.yaml
+          #region: Staging 
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -129,6 +129,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    needs: test
     # only publish on a dotnet release
     if: (github.event_name == 'release' && endsWith(github.ref, '_dotnet'))
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,16 +15,15 @@
 name: .NET Agent CI
 
 on:
-  workflow_dispatch: # manually invoke to run test job only
-  pull_request: # run test job only
-  release: # run test and publish jobs
+  workflow_dispatch: # run test job only
+  pull_request: # run check modified files / test jobs
+  release: # run check modified files / test / publish jobs
     types:
       - published
   
 env:
-  INITCONTAINER_LANGUAGE: dotnet
   K8S_OPERATOR_IMAGE_TAG: edge
-  DOTNET_AGENT_ARCHITECTURE: amd64 # this value is also hard-coded in `tests/dotnet/chart/templates/instrumentation.yaml`
+  DOTNET_AGENT_ARCHITECTURE: amd64 # We will only test one architecture for now. Probably no need to test all of them
 
 permissions:
   contents: read
@@ -68,6 +67,7 @@ jobs:
     if: needs.check-modified-files.outputs.dotnet-files-changed == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:      
+      # For some reason, Harden Runner causes setup-minikube to not work correctly
       # - name: Harden Runner
       #   uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
       #   with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,174 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: .NET Agent Test
+
+on:
+  workflow_dispatch: # manually invoke to run test job only
+  pull_request: # run test job only
+  release: # run test and publish jobs
+    types:
+      - published
+  
+env:
+  INITCONTAINER_LANGUAGE: dotnet
+  K8S_OPERATOR_IMAGE_TAG: edge
+  DOTNET_AGENT_ARCHITECTURE: amd64 # this value is also hard-coded in `tests/dotnet/chart/templates/instrumentation.yaml`
+
+permissions:
+  contents: read
+
+jobs:
+  check-modified-files:
+    name: Check whether any Dotnet-related files were modified, skip the test job if not
+    runs-on: ubuntu-latest
+    outputs:
+      dotnet-files-changed: ${{ steps.changes.outputs.dotnet-files-changed }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check whether files were modified that affect .NET build/test/publish
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            dotnet-files-changed:
+              - '.github/workflows/dotnet.yml'
+              - 'src/dotnet/**'
+              - 'tests/dotnet/**'
+
+  test:
+    name: Run Dotnet init container tests
+    runs-on: ubuntu-latest
+    needs: check-modified-files
+    # run only if files were modified or the workflow was manually invoked
+    if: needs.check-modified-files.outputs.dotnet-files-changed == 'true' || github.event_name == 'workflow_dispatch'
+
+    steps:      
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # 0.0.16
+      
+      - name: Deploy cert-manager to minikube
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5 --set installCRDs=true
+          sleep 5
+          kubectl wait --for=condition=Ready -n cert-manager --all pods
+
+      - name: Deploy New Relic k8s-agents-operator to minikube
+        run: |
+          helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
+          helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
+            --namespace=default \
+            --set=licenseKey=${{ secrets.NEW_RELIC_LICENSE_KEY }} \
+            --set=controllerManager.manager.image.tag=${{ env.K8S_OPERATOR_IMAGE_TAG }}
+          sleep 5
+          kubectl wait --for=condition=Ready -n default --all pods
+
+      - name: Build init container for e2e test
+        run: |
+          minikube image build -t e2e/newrelic-dotnet-init:e2e src/dotnet/ \
+            --build-opt=build-arg=TARGETARCH=${{ env.DOTNET_AGENT_ARCHITECTURE }}
+
+      - name: Build test app container
+        run: |
+          minikube image build -t e2e/test-app-dotnet:e2e tests/dotnet/
+
+      - name: Run e2e-test
+        uses: newrelic/newrelic-integration-e2e-action@a97ced80a4841c8c6261d1f9dca6706b1d89acb1  # 1.11.0
+        with:
+          retry_seconds: 60
+          retry_attempts: 5
+          agent_enabled: false
+          spec_path: tests/dotnet/test-specs.yml
+          account_id: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          api_key: ${{ secrets.NEW_RELIC_API_KEY }}
+          license_key: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+
+  publish:
+    runs-on: ubuntu-latest
+    # only publish on a dotnet release
+    if: (github.event_name == 'release' && endsWith(github.ref, '_dotnet'))
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Extract Agent Version from release tag
+        id: version
+        run: |
+          agent_version=${{ github.ref_name }}  # Use tag name
+          agent_version=${agent_version##v}  # Remove v prefix
+          agent_version=${agent_version%%_dotnet}  # Remove language suffix
+          echo "agent_version=${agent_version}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0
+
+      - name: Generate Docker metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # 5.5.1
+        with:
+          images: newrelic/newrelic-dotnet-init
+          tags: |
+            type=raw,value=${{ steps.version.outputs.agent_version }}
+            type=raw,value=latest
+
+      - name: Login to Docker Hub Container Registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # 3.1.0
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and publish .NET Agent multi-arch init container image
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # 5.3.0
+        with:
+          push: true
+          context: src/dotnet/
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,11 @@ on:
   release: # run check modified files / test / publish jobs
     types:
       - published
+      
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
   
 env:
   K8S_OPERATOR_IMAGE_TAG: edge

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-name: .NET Agent Test
+name: .NET Agent CI
 
 on:
   workflow_dispatch: # manually invoke to run test job only
@@ -71,7 +71,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-          disable-sudo: true
+          #disable-sudo: true
           egress-policy: audit
 
       - name: Set up Docker Buildx
@@ -85,6 +85,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io --force-update
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5 --set installCRDs=true
+          echo "waiting for cert-manager pods to be ready..."
           sleep 5
           kubectl wait --for=condition=Ready -n cert-manager --all pods --timeout=60s
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -74,6 +74,12 @@ jobs:
       #     #disable-sudo: true
       #     egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+                
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,11 +68,11 @@ jobs:
     if: needs.check-modified-files.outputs.dotnet-files-changed == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:      
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          #disable-sudo: true
-          egress-policy: audit
+      # - name: Harden Runner
+      #   uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+      #   with:
+      #     #disable-sudo: true
+      #     egress-policy: audit
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -86,7 +86,7 @@ jobs:
           helm repo add jetstack https://charts.jetstack.io --force-update
           helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5 --set installCRDs=true
           sleep 5
-          kubectl wait --for=condition=Ready -n cert-manager --all pods
+          kubectl wait --for=condition=Ready -n cert-manager --all pods --timeout=60s
 
       - name: Deploy New Relic k8s-agents-operator to minikube
         run: |
@@ -96,7 +96,7 @@ jobs:
             --set=licenseKey=${{ secrets.NEW_RELIC_LICENSE_KEY }} \
             --set=controllerManager.manager.image.tag=${{ env.K8S_OPERATOR_IMAGE_TAG }}
           sleep 5
-          kubectl wait --for=condition=Ready -n default --all pods
+          kubectl wait --for=condition=Ready -n default --all pods --timeout=60s
 
       - name: Build init container for e2e test
         run: |

--- a/src/dotnet/Dockerfile
+++ b/src/dotnet/Dockerfile
@@ -10,10 +10,9 @@
 
 FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b as build
 RUN apk update && apk add ca-certificates
-ARG version
-ARG architecture
 WORKDIR /instrumentation
-RUN wget -c "https://download.newrelic.com/dot_net_agent/previous_releases/${version}/newrelic-dotnet-agent_${version}_${architecture}.tar.gz" -O - | tar -xz --strip-components 1
+ARG TARGETARCH
+RUN wget -c "https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_${TARGETARCH}.tar.gz" -O - | tar -xz --strip-components 1
 
 FROM busybox:1.36.1@sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8
 COPY --from=build /instrumentation /instrumentation

--- a/tests/dotnet/Dockerfile
+++ b/tests/dotnet/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS base
+WORKDIR /app
+EXPOSE 80
+ENV ASPNETCORE_URLS=http://+:80
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+WORKDIR /src
+RUN dotnet new webapi --name WeatherForecast --output ./
+RUN dotnet publish -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+# test by browsing to http://<hostname>:<port>/WeatherForecast
+ENTRYPOINT ["dotnet", "WeatherForecast.dll"]

--- a/tests/dotnet/chart/.helmignore
+++ b/tests/dotnet/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tests/dotnet/chart/Chart.yaml
+++ b/tests/dotnet/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-app-dotnet
+description: A Helm chart for Kubernetes
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/tests/dotnet/chart/templates/deployment.yaml
+++ b/tests/dotnet/chart/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
           - name: NEW_RELIC_LOG_CONSOLE
             value: "1"
           # set the host to staging if using a staging license key
-          - name: NEW_RELIC_HOST
-            value: staging-collector.newrelic.com
+          #- name: NEW_RELIC_HOST
+          #  value: staging-collector.newrelic.com
 ---
 apiVersion: v1
 kind: Service

--- a/tests/dotnet/chart/templates/deployment.yaml
+++ b/tests/dotnet/chart/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             value: k8s-e2e-test-app-dotnet
           # used by the e2e Github action
           - name: NEW_RELIC_LABELS
-            value: "testKey:{{ .Values.scenarioTag | default "NOTSET" }}"
+            value: 'testKey:{{ .Values.scenarioTag | default "NOTSET" }}'
           # for testing, comment out if not needed
           - name: NEWRELIC_LOG_LEVEL
             value: finest

--- a/tests/dotnet/chart/templates/deployment.yaml
+++ b/tests/dotnet/chart/templates/deployment.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-dotnet
+spec:
+  selector:
+    matchLabels:
+      app: test-app-dotnet
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app-dotnet
+      annotations:
+        instrumentation.newrelic.com/inject-dotnet: "true"
+    spec:
+      containers:
+        - name: test-app-dotnet
+          image: e2e/test-app-dotnet:e2e
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 80
+          env:
+          - name: NEW_RELIC_APP_NAME
+            value: k8s-e2e-test-app-dotnet
+          # used by the e2e Github action
+          - name: NEW_RELIC_LABELS
+            value: "testKey:{{ .Values.scenarioTag | default "NOTSET" }}"
+          # for testing, comment out if not needed
+          - name: NEWRELIC_LOG_LEVEL
+            value: finest
+          - name: NEW_RELIC_LOG_CONSOLE
+            value: "1"
+          # set the host to staging if using a staging license key
+          - name: NEW_RELIC_HOST
+            value: staging-collector.newrelic.com
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app-dotnet-service
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: test-app-dotnet

--- a/tests/dotnet/chart/templates/instrumentation.yaml
+++ b/tests/dotnet/chart/templates/instrumentation.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: newrelic.com/v1alpha1
+kind: Instrumentation
+metadata:
+  labels:
+    app.kubernetes.io/name: instrumentation
+    app.kubernetes.io/created-by: newrelic-agent-operator
+  name: newrelic-instrumentation
+spec:
+  dotnet:
+    image: e2e/newrelic-dotnet-init:e2e
+

--- a/tests/dotnet/chart/values.yaml
+++ b/tests/dotnet/chart/values.yaml
@@ -1,0 +1,1 @@
+scenarioTag: ""

--- a/tests/dotnet/test-specs.yml
+++ b/tests/dotnet/test-specs.yml
@@ -1,0 +1,15 @@
+description: End-to-end tests for dotnet initcontainer
+custom_test_key: tags.testKey
+scenarios:
+  - description: This scenario will verify that a transaction is reported by the test app after a curl request
+    before:
+      - helm install test-dotnet ./chart/ --set=scenarioTag="${SCENARIO_TAG}" -n default
+      - sleep 5
+      - kubectl wait --for=condition=Ready -n default --all pods
+      - curl --fail-with-body $(minikube service test-app-dotnet-service --url -n default)/WeatherForecast
+    tests:
+      nrqls:
+        - query: SELECT latest(duration) AS duration FROM Transaction WHERE appName = 'k8s-e2e-test-app-dotnet'
+          expected_results:
+            - key: "duration"
+              lowerBoundedValue: 0.0


### PR DESCRIPTION
* Adds a workflow for the .NET init container test and build
* Adds tests for .NET

Things to note:
* ~I'm using [step-security/harden-runner](https://github.com/step-security/harden-runner) on all jobs which is a best practice for identifying and mitigating any potential monkey business by bad actors~ -- Apparently there's some interaction between `harden-runner` and `setup-minikube`. We'll need to look into that at some point.
* The workflow also uses `dorny/paths-filter` to check whether any files relevant to the .NET init container were modified and does not run the `test` job if no files were modified
* I added a `workflow_dispatch` trigger so the workflow (the `test` job, at least) can be manually invoked for testing and debugging.

Much to my surprise and amazement, the `test` job actually ran to completion, including a successful e2e test (once I made a few tweaks)!