### PR TITLE
ci: Refactor dotnet workflow to extract reusable workflow for checking modified files

### DIFF
--- a/.github/workflows/check-modified-files.yml
+++ b/.github/workflows/check-modified-files.yml
@@ -1,0 +1,63 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+    name: Check for modified files
+    
+    on:
+      workflow_call:
+        inputs:
+          agent-language:
+            description: Agent language (dotnet, go, java, node, php, python or ruby)
+            type: string
+            required: true
+        outputs:
+          files-changed: 
+            value: ${{ jobs.check-modified-files.outputs.files-changed }}
+            description: Returns 'true' or 'false'
+    
+    permissions:
+      contents: read
+    
+    jobs:
+      check-modified-files:
+        name: Check whether any relevant files were modified
+        runs-on: ubuntu-latest
+        outputs:
+          files-changed: ${{ steps.changes.outputs.files-changed }}
+    
+        steps:
+          - name: Harden Runner
+            uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+            with:
+              disable-sudo: true
+              egress-policy: audit
+    
+          - name: Checkout code
+            uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+            with:
+              persist-credentials: false
+              fetch-depth: 0
+    
+          - name: Check whether files were modified that affect ${{ inputs.agent-language}} build/test/publish
+            uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+            id: changes
+            with:
+              base: ${{ github.ref }}
+              filters: |
+                files-changed:
+                  - '.github/workflows/${{ inputs.agent-language }}.yml'
+                  - 'src/${{ inputs.agent-language }}/**'
+                  - 'tests/${{ inputs.agent-language }}/**'
+    
+    

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,40 +36,19 @@ permissions:
 jobs:
   check-modified-files:
     name: Check whether any Dotnet-related files were modified, skip the test job if not
-    runs-on: ubuntu-latest
-    outputs:
-      dotnet-files-changed: ${{ steps.changes.outputs.dotnet-files-changed }}
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
-        with:
-          disable-sudo: true
-          egress-policy: audit
-
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Check whether files were modified that affect .NET build/test/publish
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            dotnet-files-changed:
-              - '.github/workflows/dotnet.yml'
-              - 'src/dotnet/**'
-              - 'tests/dotnet/**'
+    uses: ./.github/workflows/check-modified-files.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      agent-language: dotnet
 
   test:
     name: Run Dotnet init container tests
     runs-on: ubuntu-latest
     needs: check-modified-files
     # run only if files were modified or the workflow was manually invoked
-    if: needs.check-modified-files.outputs.dotnet-files-changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.check-modified-files.outputs.files-changed == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:      
       # For some reason, Harden Runner causes setup-minikube to not work correctly

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,8 +32,20 @@ env:
   K8S_OPERATOR_IMAGE_TAG: edge
 
 jobs:
+  check-modified-files:
+    name: Check whether any Python-related files were modified, skip the test job if not
+    uses: ./.github/workflows/check-modified-files.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      agent-language: python
+      
   test:
     runs-on: ubuntu-latest
+    needs: check-modified-files
+    # run only if Python-related files were modified
+    if: needs.check-modified-files.outputs.files-changed == 'true'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Converts the `check-modified-files` job into a reusable workflow and refactors `dotnet.yml` to call that workflow. Also modifies `python.yml` to use the new workflow.