### PR TITLE
feat: Added reusable test and publish workflows

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -1,0 +1,81 @@
+name: "NodeJs Init Container CI"
+
+on:
+  pull_request:
+    paths:
+      - 'src/nodejs/**'
+      - '.github/workflows/nodejs.yaml'
+  push:
+    paths:
+      - 'nodejs/**'
+      - '.github/workflows/nodejs.yaml'
+    branches:
+      - main
+    # Do not run when a tag is created.
+    tags-ignore:
+      - "**"
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+env:
+  INITCONTAINER_LANGUAGE: nodejs
+  K8S_OPERATOR_IMAGE_TAG: edge
+
+jobs:
+  set-agent-version:
+    if: github.event_name == 'release' && endsWith(github.ref, '_nodejs') # Skip everything if this isn't Node
+    runs-on: ubuntu-latest
+
+  call-test:
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: ${{ matrix.node-version }}
+
+  call-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - set-agent-version
+      - call-test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16, 18, 20]
+        agent-version: ['latest']
+
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          INITCONTAINER_LANGUAGE: ${{ env.INITCONTAINER_LANGUAGE }}
+          K8S_OPERATOR_IMAGE_TAG: ${{ env.K8S_OPERATOR_IMAGE_TAG }}
+          RUNTIME_VERSION: ${{ matrix.node-version }}
+
+      - name: Get agent version
+        run: |
+          if [[ ${{ matrix.agent-version }} == 'latest' ]]; then
+            cd nodejs && npm i newrelic@${{ matrix.agent-version }} && cd ..
+            echo AGENT_VERSION=$(cat nodejs/package.json | jq -r '.dependencies."newrelic"') >> $GITHUB_ENV 
+          elif 
+            echo AGENT_VERSION=${{ matrix.agent-version }} >> $GITHUB_ENV 
+          fi
+
+      - name: Format Agent Version
+        id: version
+        run: |
+          agent_version=${{ env.AGENT_VERSION }}  # Use output
+          echo NEW_RELIC_AGENT_VERSION=${{ env.AGENT_VERSION }} >> $GITHUB_ENV # Make ure to send the agent version to the dockerfile
+          agent_version=${agent_version##v}  # Remove v prefix
+          agent_version=${agent_version%%_${{ env.INITCONTAINER_LANGUAGE }}}  # Remove language suffix
+          agent_version=${agent_version}}_nodejs${{ matrix.node-version }}x  # Add Node runtime
+          echo "agent_version=${agent_version}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Call Publish Workflow for ${{ matrix.node-version }}
+        uses: ./.github/workflows/publish.yml
+        with:
+          INITCONTAINER_LANGUAGE: ${{ env.INITCONTAINER_LANGUAGE }}
+          K8S_OPERATOR_IMAGE_TAG: ${{ env.K8S_OPERATOR_IMAGE_TAG }}
+          NEW_RELIC_AGENT_VERSION: ${{ env.NEW_RELIC_AGENT_VERSION }}
+          AGENT_VERSION_TAG: ${{steps.version.output.agent_version}}
+          RUNTIME_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Init Container Publish
+
+on:
+  workflow_call:
+    inputs:
+      INITCONTAINER_LANGUAGE:
+        required: true
+        type: string
+      K8S_OPERATOR_IMAGE_TAG:
+        required: true
+        type: string
+      NEW_RELIC_AGENT_VERSION:
+        required: true
+        type: string
+      AGENT_VERSION_TAG:
+        required: false
+        type: string
+      RUNTIME_VERSION:
+        required: false
+        type: string
+      ARCHITECTURE:
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+
+      - name: Set architecture or use default
+        run: |
+          if [[ ${{ input.ARCHITECTURE }} != '' ]]; then
+            echo architecture="${{ input.ARCHITECTURE }}" >> $GITHUB_ENV 
+          elif 
+            echo architecture="linux/amd64,linux/arm64,linux/arm" >> $GITHUB_ENV 
+          fi
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0
+
+      - name: Generate Docker metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # 5.5.1
+        with:
+          images: newrelic/newrelic-${{ input.INITCONTAINER_LANGUAGE }}-init
+          tags: |
+            type=raw,value=${{ input.AGENT_VERSION_TAG }}
+            type=raw,value=latest
+
+      - name: Login to Docker Hub Container Registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # 3.1.0
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and publish init container image
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # 5.3.0
+        with:
+          push: true
+          context: src/${{ input.INITCONTAINER_LANGUAGE }}/
+          platforms: ${{ env.architecture }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEW_RELIC_AGENT_VERSION=${{ input.NEW_RELIC_AGENT_VERSION }}
+            RUNTIME_VERSION=${{ input.RUNTIME_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,82 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Init Container Test
+
+on:
+  workflow_call:
+    inputs:
+      INITCONTAINER_LANGUAGE:
+        required: true
+        type: string
+      K8S_OPERATOR_IMAGE_TAG:
+        required: true
+        type: string
+      RUNTIME_VERSION:
+        required: false
+        type: string
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # 3.3.0
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # 0.0.16
+
+      - name: Deploy cert-manager to minikube
+        run: |
+          helm repo add jetstack https://charts.jetstack.io --force-update
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5 --set installCRDs=true
+          sleep 5
+          kubectl wait --for=condition=Ready -n cert-manager --all pods
+
+      - name: Deploy New Relic k8s-agents-operator to minikube
+        run: |
+          helm repo add k8s-agents-operator https://newrelic.github.io/k8s-agents-operator
+          helm upgrade --install k8s-agents-operator k8s-agents-operator/k8s-agents-operator \
+            --namespace=default \
+            --set=licenseKey=${{ secrets.NEW_RELIC_LICENSE_KEY }} \
+            --set=controllerManager.manager.image.tag=${{ inputs.K8S_OPERATOR_IMAGE_TAG }}
+          sleep 5
+          kubectl wait --for=condition=Ready -n default --all pods
+
+      - name: Build init container
+        run: |
+          minikube image build -t e2e/newrelic-${{ inputs.INITCONTAINER_LANGUAGE }}-init:e2e src/${{ inputs.INITCONTAINER_LANGUAGE }}/
+
+      - name: Build test app container
+        run: |
+          minikube image build -t e2e/test-app-${{ inputs.INITCONTAINER_LANGUAGE }}:e2e tests/${{ inputs.INITCONTAINER_LANGUAGE }}/
+
+      - name: Run e2e-test
+        uses: newrelic/newrelic-integration-e2e-action@a97ced80a4841c8c6261d1f9dca6706b1d89acb1  # 1.11.0
+        with:
+          retry_seconds: 60
+          retry_attempts: 5
+          agent_enabled: false
+          spec_path: tests/${{ inputs.INITCONTAINER_LANGUAGE }}/test-specs.yml
+          account_id: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          api_key: ${{ secrets.NEW_RELIC_API_KEY }}
+          license_key: ${{ secrets.NEW_RELIC_LICENSE_KEY }}

--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -6,13 +6,13 @@
 #   Then in the second stage, copy the directory to `/instrumentation`.
 # - Ensure you have `newrelic`, and`@newrelic/native-metrics`.
 # - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
-ARG NODE_RUNTIME_VERSION=20
-ARG NEWRELIC_NODE_AGENT_VERSION=latest
+ARG RUNTIME_VERSION=20
+ARG NEW_RELIC_AGENT_VERSION=latest
 
-FROM node:${NODE_RUNTIME_VERSION} AS build
+FROM node:${RUNTIME_VERSION} AS build
 WORKDIR /operator-build
 COPY . .
-RUN npm install newrelic@${NEWRELIC_NODE_AGENT_VERSION}
+RUN npm install newrelic@${NEW_RELIC_AGENT_VERSION}
 
 FROM busybox
 COPY --from=build /operator-build/build/workspace /instrumentation


### PR DESCRIPTION
This draft is an example of how we'd use reusable test and publish workflows, in this case for Node. 

Node is going to publish containers for multiple versions of the Node runtime, so there's a matrix for those versions, and the publish job is augmented to pass that along to the Dockerfile.

I expect to have to update this and the test.yml in response to the latest updates to the Python workflows, but wanted to get this in front of people. 