### PR TITLE
ci: Remove sha pin in dotnet/Dockerfile

### DIFF
--- a/src/dotnet/Dockerfile
+++ b/src/dotnet/Dockerfile
@@ -8,12 +8,12 @@
 #    CORECLR_PROFILER_PATH=%InstallationLocation%/libNewRelicProfiler.so
 #    CORECLR_NEWRELIC_HOME=%InstallationLocation% 
 
-FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b as build
+FROM alpine as build
 RUN apk update && apk add ca-certificates
 WORKDIR /instrumentation
 ARG TARGETARCH
 RUN wget -c "https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_${TARGETARCH}.tar.gz" -O - | tar -xz --strip-components 1
 
-FROM busybox:1.36.1@sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8
+FROM busybox
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation


### PR DESCRIPTION
multi-arch build failed, possibly because of the sha pinning in Dockerfile. This is a test to see if it resolves the multi-arch problem.