### PR TITLE
chore: Removed diagnostic check for availability of license key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,6 @@ on:
         type: string
 
 jobs:
-  check-license-key:
-    name: Check secret is accessible
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test
-        run: |
-          NEW_RELIC_LICENSE_KEY="${{ secrets.NEW_RELIC_LICENSE_KEY }}"
-          echo ${#NEW_RELIC_LICENSE_KEY}
-
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
During a debugging session on the shared test workflow, we found that the license key secret wasn't available to workflow runs when the workflow is in a PR from a fork. To check for the availability of the key, we inserted this job that logs the length of the secret. This check isn't necessary now that we've determined that secrets are available as documented. 