### PR TITLE
feat(dotnet): Adds an `agentinfo.json` file and updates Dockerfile to copy that file into the init container.

### DIFF
--- a/src/dotnet/Dockerfile
+++ b/src/dotnet/Dockerfile
@@ -21,6 +21,9 @@ ARG TARGETARCH
 ARG AGENT_VERSION
 RUN /dotnet-agent-download.sh $TARGETARCH $AGENT_VERSION
 
+# replace agentinfo.json from the tarball with one that identifies this as a k8s-operator install type
+COPY agentinfo.json .
+
 FROM busybox
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/dotnet/agentinfo.json
+++ b/src/dotnet/agentinfo.json
@@ -1,0 +1,3 @@
+{
+    "install_type": "k8s-operator"
+}


### PR DESCRIPTION
The .NET agent already uses `agentinfo.json` to identify the install type for the agent; this PR updates the .NET init container build process to inject an `agentinfo.json` file that identifies the installation as `k8s-operator`. 