### PR TITLE
test(dotnet): Add `newrelic.config` for test app

### DIFF
--- a/tests/dotnet/Dockerfile
+++ b/tests/dotnet/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY --from=build /app/publish .
 
 COPY newrelic.config .
+RUN chmod ugo+r newrelic.config
 
 # test by browsing to http://<hostname>:<port>/WeatherForecast
 ENTRYPOINT ["dotnet", "WeatherForecast.dll"]

--- a/tests/dotnet/Dockerfile
+++ b/tests/dotnet/Dockerfile
@@ -13,7 +13,6 @@ WORKDIR /app
 COPY --from=build /app/publish .
 
 COPY newrelic.config .
-RUN chmod ugo+r newrelic.config
 
 # test by browsing to http://<hostname>:<port>/WeatherForecast
 ENTRYPOINT ["dotnet", "WeatherForecast.dll"]

--- a/tests/dotnet/Dockerfile
+++ b/tests/dotnet/Dockerfile
@@ -12,5 +12,7 @@ FROM base AS final
 WORKDIR /app
 COPY --from=build /app/publish .
 
+COPY newrelic.config .
+
 # test by browsing to http://<hostname>:<port>/WeatherForecast
 ENTRYPOINT ["dotnet", "WeatherForecast.dll"]

--- a/tests/dotnet/newrelic.config
+++ b/tests/dotnet/newrelic.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) 2008-2020 New Relic, Inc.  All rights reserved. -->
+<!-- For more information see: https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ -->
+<configuration xmlns="urn:newrelic-config" agentEnabled="true">
+	<service syncStartup="true" sendDataOnExit="true" sendDataOnExitThreshold="0" />
+</configuration>

--- a/tests/dotnet/test-specs.yml
+++ b/tests/dotnet/test-specs.yml
@@ -6,6 +6,7 @@ scenarios:
       - helm install test-dotnet ./chart/ --set=scenarioTag="${SCENARIO_TAG}" -n default
       - sleep 5
       - kubectl wait --for=condition=Ready -n default --all pods
+      - sleep 15 # give the agent time to connect
       - curl --fail-with-body $(minikube service test-app-dotnet-service --url -n default)/WeatherForecast
     tests:
       nrqls:


### PR DESCRIPTION
Adds a `newrelic.config` to the e2e test app that configures a few options to help ensure the .NET agent starts up synchronously. This is aimed at improving e2e test reliability.