### PR TITLE
ci: Security Hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+

--- a/.github/scorecard.yml
+++ b/.github/scorecard.yml
@@ -1,0 +1,78 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '36 7 * * 4'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: "Checkout code"
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@2e230e8fe0ad3a14a340ad0815ddb96d599d2aff # v3.25.8
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,9 @@ on:
     types:
       - published
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   test:
     if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_dotnet')) # Skip everything if this isn't .NET

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -28,6 +28,9 @@ on:
     types:
       - published
 
+# Declare default permissions as read only.
+permissions: read-all
+  
 jobs:
   test:
     if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_java')) # Skip everything if this isn't Java

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,7 @@ on:
 env:
   INITCONTAINER_LANGUAGE: nodejs
 
-  # Declare default permissions as read only.
+# Declare default permissions as read only.
 permissions: read-all
 
 jobs:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,6 +31,9 @@ on:
 env:
   INITCONTAINER_LANGUAGE: nodejs
 
+  # Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   test:
     if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_nodejs')) # Skip everything if this isn't Node

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,9 @@ on:
     types:
       - published
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   test:
     if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_python')) # Skip everything if this isn't Python

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,9 @@ on:
     types:
       - published
 
+# Declare default permissions as read only.
+permissions: read-all
+  
 jobs:
   test:
     if: github.event_name != 'release' || (github.event_name == 'release' && endsWith(github.ref, '_ruby')) # Skip everything if this isn't Ruby


### PR DESCRIPTION
A few changes aimed at security hardening for this repo:
* Adds top-level default permissions to the language agent workflows. Individual jobs can still specify the permissions they need.
* Adds a `dependabot.yml` to enable Dependabot to open PRs for dependency updates. Note that I've included `docker` in the list of ecosystems; we will need to let it run once or twice to determine whether it is useful or not. 
* Adds a `scorecard.yml` workflow to enable [OpenSSF Scorecard analysis](https://github.com/ossf/scorecard?tab=readme-ov-file#overview-1) of the repo. Issues will appear under the "Security" tab on the repo and can be addressed either with a code change or manual dismissal if the issue isn't relevant.