### PR TITLE
chore: Code scanning alert fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ on:
         type: boolean
         default: false
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
         required: false
         type: string
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   test:
     name: Run E2E tests for ${{ inputs.INITCONTAINER_LANGUAGE }}

--- a/src/dotnet/Dockerfile
+++ b/src/dotnet/Dockerfile
@@ -8,7 +8,7 @@
 #    CORECLR_PROFILER_PATH=%InstallationLocation%/libNewRelicProfiler.so
 #    CORECLR_NEWRELIC_HOME=%InstallationLocation% 
 
-FROM alpine as build
+FROM alpine:latest@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd as build
 RUN apk update && apk add ca-certificates
 WORKDIR /instrumentation
 
@@ -24,6 +24,6 @@ RUN /dotnet-agent-download.sh $TARGETARCH $AGENT_VERSION
 # replace agentinfo.json from the tarball with one that identifies this as a k8s-operator install type
 COPY agentinfo.json .
 
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/java/Dockerfile
+++ b/src/java/Dockerfile
@@ -2,7 +2,7 @@
 #  - Download the newrelic java agent jar file to `/newrelic-agent.jar` using the java-agent-download.sh.
 #    This is required as when instrumenting the pod, one init container will be created to copy the jar to your app's container.
 #  - Grant the necessary access to the jar. `chmod -R go+r /newrelic-agent.jar`
-FROM alpine as build
+FROM alpine:latest@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd as build
 RUN apk update && apk add ca-certificates
 WORKDIR /instrumentation
 
@@ -14,7 +14,7 @@ RUN chmod +x /java-agent-download.sh
 ARG AGENT_VERSION
 RUN /java-agent-download.sh $AGENT_VERSION
 
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 COPY --from=build /newrelic-agent.jar /newrelic-agent.jar
 # Set executable permissions on Java agent jar file
 RUN chmod -R go+r /newrelic-agent.jar

--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -20,6 +20,6 @@ RUN npm install newrelic@${AGENT_VERSION}
 COPY newrelicinstrumentation.js .
 
 # initcontainer
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/php/Dockerfile
+++ b/src/php/Dockerfile
@@ -2,7 +2,7 @@
 #  - Download the newrelic php artefacts to `/instrumentation` directory. This is required as when instrumenting the pod,
 #    one init container will be created to copy the files to your app's container.
 #  - Grant the necessary access to the files in the `/instrumentation` directory.
-FROM alpine:latest as build
+FROM alpine:latest@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd as build
 RUN apk update && apk add ca-certificates
 ARG version
 ARG architecture
@@ -10,6 +10,6 @@ ARG php
 WORKDIR /instrumentation
 RUN wget -c "https://download.newrelic.com/php_agent/release/newrelic-${php}-${version}-${architecture}.tar.gz" -O - | tar -xz --strip-components 1
 
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 COPY --from=build /instrumentation /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -8,7 +8,7 @@
 #   Those two packages are essential to Python auto-instrumentation.
 # - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
 
-FROM python:3.10-alpine AS build
+FROM python:3.10-alpine@sha256:7e73eab259b777c76ad93e42180d468f326eff315c212bc80d4dffdf4695163a AS build
 
 WORKDIR /operator-build
 
@@ -41,7 +41,7 @@ COPY newrelic_k8s_operator.py ./workspace/
 COPY sitecustomize.py ./workspace/sitecustomize.py
 
 # initcontainer
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 
 COPY --from=build /operator-build/workspace /instrumentation
 RUN chmod -R go+r /instrumentation

--- a/src/ruby/Dockerfile
+++ b/src/ruby/Dockerfile
@@ -3,7 +3,7 @@
 #   one init container will be created to copy all the content in `/instrumentation` directory to your app's container.
 # - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
 
-FROM ruby:latest AS build
+FROM ruby:latest@sha256:8584c968202ea356984262c4422461ee3a6022c0c4d8fb517b7b9c6395556670 AS build
 WORKDIR /operator-build
 
 ARG AGENT_VERSION
@@ -12,7 +12,7 @@ ARG AGENT_VERSION
 ADD Gemfile .
 RUN BUNDLE_PATH=workspace bundle install
 
-FROM busybox
+FROM busybox:latest@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 
 # Copy build artifacts from previous
 COPY --from=build /operator-build /operator-build


### PR DESCRIPTION
Updates to address a number of currently open [code scanning alerts](https://github.com/newrelic/newrelic-agent-init-container-releases/security/code-scanning). 

Primarily, updates `Dockerfile` everywhere to pin the source image versions to a `sha256` digest. Note that the digest values were extracted using the [Crane tool](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) (`crane digest <image>`) and will be valid for multi-platform builds. 