### PR TITLE
chore(php): add secondary appname mapping

### DIFF
--- a/src/php/nrini.mapping
+++ b/src/php/nrini.mapping
@@ -4,6 +4,7 @@ NEW_RELIC_LOGFILE:newrelic.logfile
 NEW_RELIC_LOGLEVEL:newrelic.loglevel
 NEW_RELIC_HIGH_SECURITY:newrelic.high_security
 NEW_RELIC_APPNAME:newrelic.appname
+NEW_RELIC_APP_NAME:newrelic.appname
 NEW_RELIC_PROCESS_HOST_DISPLAY_NAME:newrelic.process_host.display_name
 NEW_RELIC_DAEMON_LOGFILE:newrelic.daemon.logfile
 NEW_RELIC_DAEMON_LOGLEVEL:newrelic.daemon.loglevel

--- a/tests/php/chart/templates/deployment.yaml
+++ b/tests/php/chart/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           ports:
             - containerPort: {{ .Values.exposedPort }}
           env:
-          - name: NEW_RELIC_APPNAME
+          - name: NEW_RELIC_APP_NAME
             value: k8s-e2e-test-app-php
           # labels used by the e2e Github action
           - name: NEW_RELIC_LABELS


### PR DESCRIPTION
Adds a secondary form of the environment variable for `newrelic.appname` to better align with other agents- `NEW_RELIC_APP_NAME`

Maintains compatibility with the existing `NEW_RELIC_APPNAME` variable.

Based on @zliebersbach's PR #166, reproduced here to allow test suites to run.
