### PR TITLE
chore: Upgrade to latest agent metadata

### DIFF
--- a/.github/workflows/agent-metadata.yml
+++ b/.github/workflows/agent-metadata.yml
@@ -59,7 +59,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Run action
-        uses: newrelic/agent-metadata-action@35f8e4ce08e08eaa070ec7a7630ec065d0032694 #v1.0.8
+        uses: newrelic/agent-metadata-action@0cb0aaac380f66f9b86bbceb060ab0b2c4ea76d2 #v1.0.10
         with:
           newrelic-client-id: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
           newrelic-private-key: ${{ secrets.FC_SYS_ID_PR_KEY }}


### PR DESCRIPTION
[v1.0.8...v1.0.10](https://github.com/newrelic/agent-metadata-action/compare/v1.0.8...v1.0.10)

[Related issue](https://newrelic.slack.com/archives/C08R3QJPB0E/p1778267777338999) where errors were missed for Ruby agent