### PR TITLE
feat!: Remove Node.js 20 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
         architecture: ["linux/amd64", "linux/arm64", "linux/arm"]
         exclude:
           - node-version: 24
@@ -69,8 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - node-version: 20
-            architecture: "linux/amd64,linux/arm64,linux/arm"
           - node-version: 22
             architecture: "linux/amd64,linux/arm64,linux/arm"
           - node-version: 24

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Each Node.js container is only compatible with a single major version of Node.js
 | Image Tag        | Node.js Major Version  |
 |------------------|------------------------|
 | latest           | Latest Supported  (24) |
-| 13.0.0           | Latest Supported  (24) |
-| 13.0.0-nodejs24x | 24                     |
-| 13.0.0-nodejs22x | 22                     |
+| 14.0.0           | Latest Supported  (24) |
+| 14.0.0-nodejs24x | 24                     |
+| 14.0.0-nodejs22x | 22                     |
 
 ## Local Testing
 
@@ -134,7 +134,7 @@ crane copy $IMAGE_NAME:8.11.0.0 $IMAGE_NAME:8
 crane copy $IMAGE_NAME:8.10.1.0 $IMAGE_NAME:8.10
 ```
 
-For agents with suffixes like `-nodejs20x`, significantly more tags will need to be overwritten (see [image tagging conventions](#image-tagging-conventions)).
+For agents with suffixes like `-nodejs22x`, significantly more tags will need to be overwritten (see [image tagging conventions](#image-tagging-conventions)).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Each Node.js container is only compatible with a single major version of Node.js
 | 13.0.0           | Latest Supported  (24) |
 | 13.0.0-nodejs24x | 24                     |
 | 13.0.0-nodejs22x | 22                     |
-| 13.0.0-nodejs20x | 20                     |
 
 ## Local Testing
 

--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -6,7 +6,7 @@
 #   Then in the second stage, copy the directory to `/instrumentation`.
 # - Ensure you have `newrelic`, and`@newrelic/native-metrics`.
 # - Grant the necessary access to `/instrumentation` directory. `chmod -R go+r /instrumentation`
-ARG RUNTIME_VERSION=20
+ARG RUNTIME_VERSION=22
 
 FROM node:${RUNTIME_VERSION} AS build
 


### PR DESCRIPTION
With version 14 of the Node agent, we dropped support for Node 20.