### PR TITLE
chore: pin dotnet-windows base images by hash for all TARGETARCH values

### DIFF
--- a/src/dotnet-windows/Dockerfile
+++ b/src/dotnet-windows/Dockerfile
@@ -6,11 +6,15 @@
 #    https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-core-env-variables
 
 # This container needs to match the target architecture.
-# Valid TARGETARCH: ltsc2022, ltsc2025
-ARG TARGETARCH
+# Valid TARGETARCH: 2022, 2025
+ARG TARGETARCH=2025
+
+# Pin both possible base images by hash; the final FROM selects between them at build time.
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022@sha256:33a88d0a3359267ff4d2b85f1b6cd4b6eafd69b81218f5ccb849229cd7e560f9 AS base-2022
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:4d60fd27581d94a2866c7b54b3ade605de37a74e11aa8314a963fb3272a67667 AS base-2025
 
 # This container can be pinned to latest OS since all it does is get the data which is OS agnostic.
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:af9cf5183e68ff0beee87a795e5761ef9143fc6ee7e3d785b5920eda6f5e03fb as build
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025@sha256:4d60fd27581d94a2866c7b54b3ade605de37a74e11aa8314a963fb3272a67667 AS build
 
 # Set the working directory
 WORKDIR C:\\instrumentation
@@ -28,7 +32,7 @@ COPY agentinfo.json .
 COPY agentinfo.json .\\netcore\\agentinfo.json
 COPY agentinfo.json .\\netframework\\agentinfo.json
 
-# This container needs to match the target architecture.
-FROM mcr.microsoft.com/windows/nanoserver:ltsc${TARGETARCH}
+# Select the pre-pinned base image for the target architecture.
+FROM base-${TARGETARCH}
 
 COPY --from=build /instrumentation /instrumentation


### PR DESCRIPTION
## Summary

- Resolves OSSF Scorecard alert 48 (PinnedDependenciesID) — the final `FROM` in `src/dotnet-windows/Dockerfile` was unpinned because it used `ltsc${TARGETARCH}` with a build arg
- Adds both `ltsc2022` and `ltsc2025` as named, digest-pinned stages (`base-2022`, `base-2025`); the final stage selects between them via `FROM base-${TARGETARCH}`, which Docker treats as an internal stage reference rather than an external image pull
- Updates both `ltsc2025` pins to the latest digest and adds `ltsc2022` with its current digest (Dependabot will manage both going forward)
- Fixes `as build` casing to `AS build` for consistency

## Test plan

- [ ] Verify build succeeds with `--build-arg TARGETARCH=2025` on a Windows runner
- [ ] Verify build succeeds with `--build-arg TARGETARCH=2022` on a Windows runner
- [ ] Confirm Scorecard PinnedDependencies alert 48 closes after merge