### PR TITLE
ci: make Windows init container builds resilient to Docker flakiness

### DIFF
--- a/.github/actions/wait_for_docker/action.yml
+++ b/.github/actions/wait_for_docker/action.yml
@@ -1,0 +1,40 @@
+# Copyright New Relic, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Wait for Docker'
+description: 'Polls the Docker daemon until it is responsive, to absorb cold-start races on Windows runners.'
+
+inputs:
+  attempts:
+    description: "Maximum number of readiness probes before failing."
+    required: false
+    default: "30"
+  delay_seconds:
+    description: "Seconds to wait between probes."
+    required: false
+    default: "5"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Wait for Docker daemon
+      shell: pwsh
+      run: |
+        $attempts = [int]"${{ inputs.attempts }}"
+        $delay = [int]"${{ inputs.delay_seconds }}"
+
+        for ($i = 1; $i -le $attempts; $i++) {
+          # 'docker info' returns non-zero until the daemon is reachable. Native
+          # command failures don't throw, so we branch on $LASTEXITCODE.
+          docker info *> $null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Docker daemon is ready (attempt $i of $attempts)."
+            docker version
+            exit 0
+          }
+          Write-Host "Docker daemon not ready (attempt $i of $attempts); waiting $delay seconds..."
+          Start-Sleep -Seconds $delay
+        }
+
+        Write-Error "Docker daemon did not become ready after $attempts attempts."
+        exit 1

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -45,7 +45,10 @@
   
         - name: Checkout code
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
-  
+
+        - name: Wait for Docker to be available
+          uses: ./.github/actions/wait_for_docker
+
         - name: Extract Agent Version Tags
           id: version
           uses: ./.github/actions/extract_agent_version_tags
@@ -92,9 +95,19 @@
             # Build container
             $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', inputs.INITCONTAINER_LANGUAGE, inputs.TARGETARCH) }}:latest"
             
-            Write-Host "docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME ."
-            docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME .
-  
+            # Retry the build to absorb transient base-image pull throttling (e.g.
+            # MCR "request is blocked") and Docker daemon hiccups on hosted runners.
+            $maxAttempts = 3
+            for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+              Write-Host "docker build attempt $attempt of $maxAttempts"
+              Write-Host "docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME ."
+              docker build ${{ steps.prep_labels.outputs.labels }} --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ steps.version.outputs.agent_version }} -t $env:IMAGE_NAME .
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($attempt -eq $maxAttempts) { throw "docker build failed after $maxAttempts attempts." }
+              Write-Host "Build failed (exit $LASTEXITCODE); retrying in 15 seconds..."
+              Start-Sleep -Seconds 15
+            }
+
             # tag container
             Write-Host "Starting tagging process for $env:IMAGE_NAME"
             foreach ($tag in ($env:DOCKER_METADATA_OUTPUT_TAGS -split "`n")) {

--- a/.github/workflows/test-dotnet-windows.yml
+++ b/.github/workflows/test-dotnet-windows.yml
@@ -44,10 +44,8 @@ jobs:
           $agentVersion = $refName -replace '^v', '' -replace '_[a-zA-Z]*', '' -replace '\.[0-9]*$', ''
           "AGENT_VERSION=$agentVersion" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Verify Docker is available
-        run: |
-          docker version
-          docker info
+      - name: Wait for Docker to be available
+        uses: ./.github/actions/wait_for_docker
 
       - name: Build and init container image
         run: |
@@ -56,8 +54,18 @@ jobs:
           # Build container
           $env:IMAGE_NAME="local/${{ format('newrelic-{0}{1}-init', 'dotnet-windows', inputs.TARGETARCH) }}:latest"
 
-          Write-Host "docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME ."
-          docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME .
+          # Retry the build to absorb transient base-image pull throttling (e.g.
+          # MCR "request is blocked") and Docker daemon hiccups on hosted runners.
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "docker build attempt $attempt of $maxAttempts"
+            Write-Host "docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME ."
+            docker build --build-arg TARGETARCH=${{ inputs.TARGETARCH }} --build-arg AGENT_VERSION=${{ env.AGENT_VERSION }} -t $env:IMAGE_NAME .
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -eq $maxAttempts) { throw "docker build failed after $maxAttempts attempts." }
+            Write-Host "Build failed (exit $LASTEXITCODE); retrying in 15 seconds..."
+            Start-Sleep -Seconds 15
+          }
 
       # Not meant to be exhaustive, just a basic check that the image was built correctly
       - name: Run basic tests


### PR DESCRIPTION
The .NET init container release workflow needed 4 attempts to go green ([run 26909134712](https://github.com/newrelic/newrelic-agent-init-container/actions/runs/26909134712)). All failures were transient Docker infra issues on the hosted `windows-2025` runners, but the workflow had no resilience against them:

- **Docker daemon not ready** (3 of 4 failures) — `npipe:////./pipe/docker_engine ... cannot find the file specified`. Recurring; also hit an unrelated dependabot run.
- **MCR pull blocked** (1 failure) — `pull access denied for mcr.microsoft.com/windows/nanoserver ... The request is blocked`.

## Changes
- New `wait_for_docker` composite action that polls the daemon until ready; replaces the single-shot `docker version; docker info` check in `test-dotnet-windows.yml` and adds a readiness gate to `publish-windows.yml` (which had none).
- Retry `docker build` (3 attempts, 15s backoff) in both workflows to absorb transient base-image pull throttling.

Both failure modes are infra-transient, so this does not change build behavior on the happy path — it only avoids manual re-runs.