### PR TITLE
ci: restart Docker service on Windows runners when boot leaves it stopped

### DIFF
--- a/.github/actions/wait_for_docker/action.yml
+++ b/.github/actions/wait_for_docker/action.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Wait for Docker'
-description: 'Polls the Docker daemon until it is responsive, to absorb cold-start races on Windows runners.'
+description: 'Ensures the Docker daemon is running on Windows runners, restarting the service if a runner boot left it stopped, and waiting until it is responsive.'
 
 inputs:
   attempts:
@@ -32,9 +32,33 @@ runs:
             docker version
             exit 0
           }
+
+          # Known GitHub-hosted Windows runner regression: on runner boot the
+          # Docker service sometimes fails to create its Hyper-V virtual switch
+          # ("hnsCall failed in Win32: The system cannot find the file
+          # specified") and is left Stopped, so the docker_engine named pipe
+          # never appears. Restarting the service fixes it ~100% of the time.
+          # Workaround per actions/runner-images#13729; remove once fixed
+          # upstream. Affects Docker Engine v29+.
+          $svc = Get-Service -Name 'docker' -ErrorAction SilentlyContinue
+          if ($svc -and $svc.Status -ne 'Running') {
+            Write-Host "Docker service is '$($svc.Status)'; attempting Start-Service..."
+            Start-Service -Name 'docker' -ErrorAction SilentlyContinue
+          }
+
           Write-Host "Docker daemon not ready (attempt $i of $attempts); waiting $delay seconds..."
           Start-Sleep -Seconds $delay
         }
+
+        # Surface why the daemon never came up so the failure is diagnosable
+        # instead of just timing out silently.
+        Write-Host "::group::Docker diagnostics"
+        Get-Service -Name 'docker' -ErrorAction SilentlyContinue |
+          Format-Table -AutoSize | Out-String | Write-Host
+        Get-WinEvent -ProviderName 'docker' -MaxEvents 40 -ErrorAction SilentlyContinue |
+          Select-Object TimeCreated, LevelDisplayName, Message |
+          Format-List | Out-String | Write-Host
+        Write-Host "::endgroup::"
 
         Write-Error "Docker daemon did not become ready after $attempts attempts."
         exit 1


### PR DESCRIPTION
## Problem

The Windows init container CI jobs intermittently fail at **Wait for Docker to be available** — `docker info` never succeeds and the step times out after all probes (e.g. run [26969067255](https://github.com/newrelic/newrelic-agent-init-container/actions/runs/26969067255), which failed twice in a row at this step).

## Root cause

Known open GitHub runner-images regression: [actions/runner-images#13729](https://github.com/actions/runner-images/issues/13729). On runner boot from the saved image, the Docker service sometimes fails to create its Hyper-V virtual switch (`hnsCall failed in Win32: The system cannot find the file specified`) and is left **Stopped**, so the `docker_engine` named pipe never appears. It's a random per-host condition tied to **Docker Engine v29+** (the `windows-2025-vs2026` image ships Docker 29.1.5).

The existing `wait_for_docker` action only *polls* the daemon, so it can't recover a service that's Stopped — it just times out slowly.

## Fix

Per Microsoft's recommended workaround in that issue (confirmed 100% effective over 1000+ reruns): when a probe fails and the `docker` service isn't `Running`, `Start-Service docker`. Also dumps service status + recent Docker event-log entries on final failure so a genuine failure is diagnosable.

This is a sanctioned stopgap — should be removed once #13729 is fixed upstream.

## Verification

Note this bug is a random per-host lottery, so a single green run does not *prove* the fix. Verifying by observing the Windows jobs here and re-running a few times.